### PR TITLE
Update Varien.php

### DIFF
--- a/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
+++ b/app/code/core/Mage/Core/Model/Session/Abstract/Varien.php
@@ -484,7 +484,7 @@ class Mage_Core_Model_Session_Abstract_Varien extends Varien_Object
             && isset($validatorData[self::VALIDATOR_PASSWORD_CREATE_TIMESTAMP])
             && isset($sessionData[self::VALIDATOR_SESSION_EXPIRE_TIMESTAMP])
             && $validatorData[self::VALIDATOR_PASSWORD_CREATE_TIMESTAMP]
-            > $sessionData[self::VALIDATOR_SESSION_EXPIRE_TIMESTAMP] - $this->getCookie()->getLifetime()
+            > $sessionData[self::VALIDATOR_SESSION_EXPIRE_TIMESTAMP]
         ) {
             return false;
         }


### PR DESCRIPTION
SUPEE-10570v2 is the second version of SUPEE-10570 patch. Paypay crashes for guest checkout if  `$this->getCookie()->getLifetime()` is added. see https://magentary.com/glossary/supee-10570v2/